### PR TITLE
Conservative nullable

### DIFF
--- a/results/IDEA/java/lang/annotations.xml
+++ b/results/IDEA/java/lang/annotations.xml
@@ -467,9 +467,6 @@
   <item name="java.lang.ClassLoader java.net.URL getBootstrapResource(java.lang.String)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="java.lang.ClassLoader java.net.URL getResource(java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="java.lang.ClassLoader java.net.URL getSystemResource(java.lang.String)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
@@ -1626,13 +1623,7 @@
   <item name="java.lang.ThreadLocal T childValue(T) 0">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="java.lang.ThreadLocal T get()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="java.lang.ThreadLocal T initialValue()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="java.lang.ThreadLocal T setInitialValue()">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="java.lang.ThreadLocal int access$400(java.lang.ThreadLocal) 0">

--- a/results/IDEA/javax/swing/annotations.xml
+++ b/results/IDEA/javax/swing/annotations.xml
@@ -394,9 +394,6 @@
   <item name="javax.swing.JTable javax.swing.table.JTableHeader createDefaultTableHeader()">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="javax.swing.JTable javax.swing.table.TableCellEditor getCellEditor(int, int)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.swing.JTable javax.swing.table.TableCellEditor getDefaultEditor(java.lang.Class) 0">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
@@ -404,9 +401,6 @@
     <annotation name="org.jetbrains.annotations.Contract">
       <val val="&quot;null-&gt;null&quot;"/>
     </annotation>
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="javax.swing.JTable javax.swing.table.TableCellRenderer getCellRenderer(int, int)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="javax.swing.JTable javax.swing.table.TableCellRenderer getDefaultRenderer(java.lang.Class) 0">

--- a/results/IDEA/org/apache/commons/collections/annotations.xml
+++ b/results/IDEA/org/apache/commons/collections/annotations.xml
@@ -20,12 +20,6 @@
   <item name="org.apache.commons.collections.ExtendedProperties java.lang.String escape(java.lang.String)">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="org.apache.commons.collections.ExtendedProperties java.lang.String getString(java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="org.apache.commons.collections.ExtendedProperties java.lang.String getString(java.lang.String, java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="org.apache.commons.collections.ExtendedProperties java.lang.String interpolate(java.lang.String)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>

--- a/results/jdk7-rt.jar/com/sun/corba/se/impl/encoding/annotations.xml
+++ b/results/jdk7-rt.jar/com/sun/corba/se/impl/encoding/annotations.xml
@@ -208,15 +208,6 @@
   <item name="com.sun.corba.se.impl.encoding.CDRInputStream_1_0 java.lang.Object readIDLValueWithHelper(com.sun.org.omg.CORBA.portable.ValueHelper, int)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="com.sun.corba.se.impl.encoding.CDRInputStream_1_0 java.lang.Object read_Abstract()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="com.sun.corba.se.impl.encoding.CDRInputStream_1_0 java.lang.Object read_abstract_interface()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="com.sun.corba.se.impl.encoding.CDRInputStream_1_0 java.lang.Object read_abstract_interface(java.lang.Class)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.corba.se.impl.encoding.CDRInputStream_1_0 java.lang.String internalReadString(int)">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
@@ -793,15 +784,6 @@
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="com.sun.corba.se.impl.encoding.IDLJavaSerializationInputStream java.io.Serializable read_value(org.omg.CORBA.portable.BoxedValueHelper) 0">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="com.sun.corba.se.impl.encoding.IDLJavaSerializationInputStream java.lang.Object read_Abstract()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="com.sun.corba.se.impl.encoding.IDLJavaSerializationInputStream java.lang.Object read_abstract_interface()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="com.sun.corba.se.impl.encoding.IDLJavaSerializationInputStream java.lang.Object read_abstract_interface(java.lang.Class)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="com.sun.corba.se.impl.encoding.IDLJavaSerializationInputStream java.math.BigDecimal read_fixed()">

--- a/results/jdk7-rt.jar/com/sun/corba/se/impl/protocol/annotations.xml
+++ b/results/jdk7-rt.jar/com/sun/corba/se/impl/protocol/annotations.xml
@@ -101,9 +101,6 @@
   <item name="com.sun.corba.se.impl.protocol.CorbaClientRequestDispatcherImpl com.sun.corba.se.pept.encoding.InputObject marshalingComplete(java.lang.Object, com.sun.corba.se.pept.encoding.OutputObject) 1">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="com.sun.corba.se.impl.protocol.CorbaClientRequestDispatcherImpl com.sun.corba.se.pept.encoding.InputObject marshalingComplete(java.lang.Object, com.sun.corba.se.pept.encoding.OutputObject)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.corba.se.impl.protocol.CorbaClientRequestDispatcherImpl com.sun.corba.se.pept.encoding.InputObject marshalingComplete1(com.sun.corba.se.spi.orb.ORB, com.sun.corba.se.spi.protocol.CorbaMessageMediator) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>

--- a/results/jdk7-rt.jar/com/sun/java/swing/plaf/windows/annotations.xml
+++ b/results/jdk7-rt.jar/com/sun/java/swing/plaf/windows/annotations.xml
@@ -37,9 +37,6 @@
   <item name="com.sun.java.swing.plaf.windows.DesktopProperty java.lang.Object createValue(javax.swing.UIDefaults) 0">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="com.sun.java.swing.plaf.windows.DesktopProperty java.lang.Object getValueFromDesktop()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.java.swing.plaf.windows.DesktopProperty void invalidate(javax.swing.LookAndFeel) 0">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>

--- a/results/jdk7-rt.jar/com/sun/org/apache/xalan/internal/xsltc/compiler/annotations.xml
+++ b/results/jdk7-rt.jar/com/sun/org/apache/xalan/internal/xsltc/compiler/annotations.xml
@@ -918,14 +918,8 @@
     </annotation>
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="com.sun.org.apache.xalan.internal.xsltc.compiler.Parser com.sun.org.apache.xalan.internal.xsltc.compiler.SyntaxTreeNode getStylesheet(com.sun.org.apache.xalan.internal.xsltc.compiler.SyntaxTreeNode)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.org.apache.xalan.internal.xsltc.compiler.Parser com.sun.org.apache.xalan.internal.xsltc.compiler.SyntaxTreeNode loadExternalStylesheet(java.lang.String) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
-  </item>
-  <item name="com.sun.org.apache.xalan.internal.xsltc.compiler.Parser com.sun.org.apache.xalan.internal.xsltc.compiler.SyntaxTreeNode loadExternalStylesheet(java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="com.sun.org.apache.xalan.internal.xsltc.compiler.Parser com.sun.org.apache.xalan.internal.xsltc.compiler.SyntaxTreeNode parse(org.xml.sax.InputSource)">
     <annotation name="org.jetbrains.annotations.Nullable"/>

--- a/results/jdk7-rt.jar/com/sun/org/apache/xerces/internal/impl/annotations.xml
+++ b/results/jdk7-rt.jar/com/sun/org/apache/xerces/internal/impl/annotations.xml
@@ -732,14 +732,8 @@
     </annotation>
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl javax.xml.namespace.QName getAttributeName(int)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl javax.xml.namespace.QName getAttributeQName(int)">
     <annotation name="org.jetbrains.annotations.NotNull"/>
-  </item>
-  <item name="com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl javax.xml.namespace.QName getName()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl javax.xml.stream.Location getLocation()">
     <annotation name="org.jetbrains.annotations.NotNull"/>

--- a/results/jdk7-rt.jar/com/sun/org/apache/xerces/internal/impl/xs/models/annotations.xml
+++ b/results/jdk7-rt.jar/com/sun/org/apache/xerces/internal/impl/xs/models/annotations.xml
@@ -67,9 +67,6 @@
   <item name="com.sun.org.apache.xerces.internal.impl.xs.models.XSAllCM java.lang.Object oneTransition(com.sun.org.apache.xerces.internal.xni.QName, int[], com.sun.org.apache.xerces.internal.impl.xs.SubstitutionGroupHandler) 1">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="com.sun.org.apache.xerces.internal.impl.xs.models.XSAllCM java.lang.Object oneTransition(com.sun.org.apache.xerces.internal.xni.QName, int[], com.sun.org.apache.xerces.internal.impl.xs.SubstitutionGroupHandler)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.org.apache.xerces.internal.impl.xs.models.XSAllCM java.util.ArrayList checkMinMaxBounds()">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>

--- a/results/jdk7-rt.jar/com/sun/org/apache/xml/internal/dtm/ref/sax2dtm/annotations.xml
+++ b/results/jdk7-rt.jar/com/sun/org/apache/xml/internal/dtm/ref/sax2dtm/annotations.xml
@@ -20,9 +20,6 @@
   <item name="com.sun.org.apache.xml.internal.dtm.ref.sax2dtm.SAX2DTM java.lang.String getNodeValue(int)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="com.sun.org.apache.xml.internal.dtm.ref.sax2dtm.SAX2DTM java.lang.String getPrefix(int)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.org.apache.xml.internal.dtm.ref.sax2dtm.SAX2DTM java.lang.String getPrefix(java.lang.String, java.lang.String)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>

--- a/results/jdk7-rt.jar/com/sun/org/apache/xml/internal/resolver/annotations.xml
+++ b/results/jdk7-rt.jar/com/sun/org/apache/xml/internal/resolver/annotations.xml
@@ -20,15 +20,6 @@
     </annotation>
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="com.sun.org.apache.xml.internal.resolver.Catalog java.lang.String resolveDoctype(java.lang.String, java.lang.String, java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="com.sun.org.apache.xml.internal.resolver.Catalog java.lang.String resolveDocument()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="com.sun.org.apache.xml.internal.resolver.Catalog java.lang.String resolveEntity(java.lang.String, java.lang.String, java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.org.apache.xml.internal.resolver.Catalog java.lang.String resolveLocalPublic(int, java.lang.String, java.lang.String, java.lang.String) 1">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
@@ -47,19 +38,7 @@
   <item name="com.sun.org.apache.xml.internal.resolver.Catalog java.lang.String resolveLocalURI(java.lang.String)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="com.sun.org.apache.xml.internal.resolver.Catalog java.lang.String resolveNotation(java.lang.String, java.lang.String, java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="com.sun.org.apache.xml.internal.resolver.Catalog java.lang.String resolvePublic(java.lang.String, java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.org.apache.xml.internal.resolver.Catalog java.lang.String resolveSubordinateCatalogs(int, java.lang.String, java.lang.String, java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="com.sun.org.apache.xml.internal.resolver.Catalog java.lang.String resolveSystem(java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="com.sun.org.apache.xml.internal.resolver.Catalog java.lang.String resolveURI(java.lang.String)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="com.sun.org.apache.xml.internal.resolver.Catalog void addDelegate(com.sun.org.apache.xml.internal.resolver.CatalogEntry) 0">

--- a/results/jdk7-rt.jar/com/sun/org/apache/xpath/internal/compiler/annotations.xml
+++ b/results/jdk7-rt.jar/com/sun/org/apache/xpath/internal/compiler/annotations.xml
@@ -30,9 +30,6 @@
   <item name="com.sun.org.apache.xpath.internal.compiler.Compiler com.sun.org.apache.xpath.internal.Expression locationPathPattern(int)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="com.sun.org.apache.xpath.internal.compiler.Compiler com.sun.org.apache.xpath.internal.Expression matchPattern(int)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.org.apache.xpath.internal.compiler.Compiler com.sun.org.apache.xpath.internal.Expression predicate(int)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>

--- a/results/jdk7-rt.jar/com/sun/xml/internal/fastinfoset/stax/events/annotations.xml
+++ b/results/jdk7-rt.jar/com/sun/xml/internal/fastinfoset/stax/events/annotations.xml
@@ -74,9 +74,6 @@
   <item name="com.sun.xml.internal.fastinfoset.stax.events.StAXEventAllocatorBase javax.xml.stream.events.XMLEvent allocate(javax.xml.stream.XMLStreamReader) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="com.sun.xml.internal.fastinfoset.stax.events.StAXEventAllocatorBase javax.xml.stream.events.XMLEvent allocate(javax.xml.stream.XMLStreamReader)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.xml.internal.fastinfoset.stax.events.StAXEventAllocatorBase javax.xml.stream.events.XMLEvent getXMLEvent(javax.xml.stream.XMLStreamReader) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>

--- a/results/jdk7-rt.jar/com/sun/xml/internal/messaging/saaj/client/p2p/annotations.xml
+++ b/results/jdk7-rt.jar/com/sun/xml/internal/messaging/saaj/client/p2p/annotations.xml
@@ -5,16 +5,10 @@
   <item name="com.sun.xml.internal.messaging.saaj.client.p2p.HttpSOAPConnection java.net.HttpURLConnection createConnection(java.net.URL) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="com.sun.xml.internal.messaging.saaj.client.p2p.HttpSOAPConnection javax.xml.soap.SOAPMessage call(javax.xml.soap.SOAPMessage, java.lang.Object)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.xml.internal.messaging.saaj.client.p2p.HttpSOAPConnection javax.xml.soap.SOAPMessage doGet(java.net.URL) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
   <item name="com.sun.xml.internal.messaging.saaj.client.p2p.HttpSOAPConnection javax.xml.soap.SOAPMessage doGet(java.net.URL)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="com.sun.xml.internal.messaging.saaj.client.p2p.HttpSOAPConnection javax.xml.soap.SOAPMessage get(java.lang.Object)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="com.sun.xml.internal.messaging.saaj.client.p2p.HttpSOAPConnection javax.xml.soap.SOAPMessage post(javax.xml.soap.SOAPMessage, java.net.URL) 0">

--- a/results/jdk7-rt.jar/com/sun/xml/internal/stream/annotations.xml
+++ b/results/jdk7-rt.jar/com/sun/xml/internal/stream/annotations.xml
@@ -32,9 +32,6 @@
   <item name="com.sun.xml.internal.stream.StaxEntityResolverWrapper com.sun.xml.internal.stream.StaxXMLInputSource resolveEntity(com.sun.org.apache.xerces.internal.xni.XMLResourceIdentifier) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="com.sun.xml.internal.stream.StaxEntityResolverWrapper com.sun.xml.internal.stream.StaxXMLInputSource resolveEntity(com.sun.org.apache.xerces.internal.xni.XMLResourceIdentifier)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.xml.internal.stream.StaxErrorReporter javax.xml.stream.Location convertToStaxLocation(com.sun.org.apache.xerces.internal.xni.XMLLocator)">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>

--- a/results/jdk7-rt.jar/com/sun/xml/internal/stream/events/annotations.xml
+++ b/results/jdk7-rt.jar/com/sun/xml/internal/stream/events/annotations.xml
@@ -203,9 +203,6 @@
   <item name="com.sun.xml.internal.stream.events.XMLEventAllocatorImpl javax.xml.stream.events.XMLEvent allocate(javax.xml.stream.XMLStreamReader) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="com.sun.xml.internal.stream.events.XMLEventAllocatorImpl javax.xml.stream.events.XMLEvent allocate(javax.xml.stream.XMLStreamReader)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="com.sun.xml.internal.stream.events.XMLEventAllocatorImpl javax.xml.stream.events.XMLEvent getNextEvent(javax.xml.stream.XMLStreamReader) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>

--- a/results/jdk7-rt.jar/java/awt/annotations.xml
+++ b/results/jdk7-rt.jar/java/awt/annotations.xml
@@ -4337,9 +4337,6 @@
   <item name="java.awt.Toolkit java.beans.PropertyChangeSupport createPropertyChangeSupport(java.awt.Toolkit)">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="java.awt.Toolkit java.lang.Object getDesktopProperty(java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="java.awt.Toolkit java.lang.Object lazilyLoadDesktopProperty(java.lang.String) 0">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>

--- a/results/jdk7-rt.jar/java/awt/image/renderable/annotations.xml
+++ b/results/jdk7-rt.jar/java/awt/image/renderable/annotations.xml
@@ -44,9 +44,6 @@
   <item name="java.awt.image.renderable.RenderableImageOp java.awt.image.RenderedImage createRendering(java.awt.image.renderable.RenderContext)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="java.awt.image.renderable.RenderableImageOp java.awt.image.RenderedImage createScaledRendering(int, int, java.awt.RenderingHints)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="java.awt.image.renderable.RenderableImageOp java.awt.image.renderable.ParameterBlock setParameterBlock(java.awt.image.renderable.ParameterBlock) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>

--- a/results/jdk7-rt.jar/java/beans/annotations.xml
+++ b/results/jdk7-rt.jar/java/beans/annotations.xml
@@ -168,7 +168,6 @@
     <annotation name="org.jetbrains.annotations.Contract">
       <val val="&quot;null-&gt;null&quot;"/>
     </annotation>
-    <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="java.beans.Encoder java.lang.Object getAttribute(java.lang.Object)">
     <annotation name="org.jetbrains.annotations.Nullable"/>

--- a/results/jdk7-rt.jar/java/lang/annotations.xml
+++ b/results/jdk7-rt.jar/java/lang/annotations.xml
@@ -630,9 +630,6 @@
   <item name="java.lang.ClassLoader java.net.URL getBootstrapResource(java.lang.String)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="java.lang.ClassLoader java.net.URL getResource(java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="java.lang.ClassLoader java.net.URL getSystemResource(java.lang.String)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
@@ -2807,13 +2804,7 @@
   <item name="java.lang.ThreadLocal T childValue(T) 0">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="java.lang.ThreadLocal T get()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="java.lang.ThreadLocal T initialValue()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="java.lang.ThreadLocal T setInitialValue()">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="java.lang.ThreadLocal int access$400(java.lang.ThreadLocal) 0">

--- a/results/jdk7-rt.jar/java/text/annotations.xml
+++ b/results/jdk7-rt.jar/java/text/annotations.xml
@@ -763,9 +763,6 @@
   <item name="java.text.MessageFormat java.lang.Object parseObject(java.lang.String, java.text.ParsePosition)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="java.text.MessageFormat java.lang.Object[] parse(java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="java.text.MessageFormat java.lang.Object[] parse(java.lang.String, java.text.ParsePosition) 0">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>

--- a/results/jdk7-rt.jar/javax/management/modelmbean/annotations.xml
+++ b/results/jdk7-rt.jar/javax/management/modelmbean/annotations.xml
@@ -154,9 +154,6 @@
   <item name="javax.management.modelmbean.ModelMBeanInfoSupport java.lang.Object clone()">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="javax.management.modelmbean.ModelMBeanInfoSupport javax.management.Descriptor getDescriptor(java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.management.modelmbean.ModelMBeanInfoSupport javax.management.Descriptor getDescriptor(java.lang.String, java.lang.String) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>

--- a/results/jdk7-rt.jar/javax/management/relation/annotations.xml
+++ b/results/jdk7-rt.jar/javax/management/relation/annotations.xml
@@ -391,14 +391,8 @@
   <item name="javax.management.relation.RelationSupport javax.management.relation.RoleResult getAllRoles()">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="javax.management.relation.RelationSupport javax.management.relation.RoleResult getAllRolesInt(boolean, javax.management.relation.RelationService)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.management.relation.RelationSupport javax.management.relation.RoleResult getRoles(java.lang.String[]) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
-  </item>
-  <item name="javax.management.relation.RelationSupport javax.management.relation.RoleResult getRoles(java.lang.String[])">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="javax.management.relation.RelationSupport javax.management.relation.RoleResult getRolesInt(java.lang.String[], boolean, javax.management.relation.RelationService) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>

--- a/results/jdk7-rt.jar/javax/swing/annotations.xml
+++ b/results/jdk7-rt.jar/javax/swing/annotations.xml
@@ -184,9 +184,6 @@
       <val val="&quot;!null-&gt;true;null-&gt;true&quot;"/>
     </annotation>
   </item>
-  <item name="javax.swing.ActionMap java.lang.Object[] allKeys()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.swing.ActionMap java.lang.Object[] keys()">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
@@ -1237,9 +1234,6 @@
   <item name="javax.swing.InputMap java.lang.Object get(javax.swing.KeyStroke)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="javax.swing.InputMap javax.swing.KeyStroke[] allKeys()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.swing.InputMap javax.swing.KeyStroke[] keys()">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
@@ -1974,9 +1968,6 @@
   <item name="javax.swing.JEditorPane.PlainEditorKit javax.swing.text.View create(javax.swing.text.Element) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="javax.swing.JEditorPane.PlainEditorKit javax.swing.text.View create(javax.swing.text.Element)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.swing.JEditorPane.PlainEditorKit javax.swing.text.View createI18N(javax.swing.text.Element) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
@@ -2242,9 +2233,6 @@
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="javax.swing.JInternalFrame java.awt.Component getFocusOwner()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="javax.swing.JInternalFrame java.awt.Component getMostRecentFocusOwner()">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="javax.swing.JInternalFrame java.awt.Container getFocusCycleRootAncestor()">
@@ -3677,9 +3665,6 @@
   <item name="javax.swing.JTabbedPane.AccessibleJTabbedPane javax.accessibility.Accessible getAccessibleAt(java.awt.Point) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="javax.swing.JTabbedPane.AccessibleJTabbedPane javax.accessibility.Accessible getAccessibleAt(java.awt.Point)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.swing.JTabbedPane.AccessibleJTabbedPane javax.accessibility.Accessible getAccessibleChild(int)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
@@ -3885,9 +3870,6 @@
   <item name="javax.swing.JTable javax.swing.table.JTableHeader createDefaultTableHeader()">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="javax.swing.JTable javax.swing.table.TableCellEditor getCellEditor(int, int)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.swing.JTable javax.swing.table.TableCellEditor getDefaultEditor(java.lang.Class&lt;?&gt;) 0">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
@@ -3895,9 +3877,6 @@
     <annotation name="org.jetbrains.annotations.Contract">
       <val val="&quot;null-&gt;null&quot;"/>
     </annotation>
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="javax.swing.JTable javax.swing.table.TableCellRenderer getCellRenderer(int, int)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="javax.swing.JTable javax.swing.table.TableCellRenderer getDefaultRenderer(java.lang.Class&lt;?&gt;) 0">

--- a/results/jdk7-rt.jar/javax/swing/plaf/basic/annotations.xml
+++ b/results/jdk7-rt.jar/javax/swing/plaf/basic/annotations.xml
@@ -1040,9 +1040,6 @@
   <item name="javax.swing.plaf.basic.BasicFileChooserUI java.lang.String getDialogTitle(javax.swing.JFileChooser) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="javax.swing.plaf.basic.BasicFileChooserUI java.lang.String getDialogTitle(javax.swing.JFileChooser)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.swing.plaf.basic.BasicFileChooserUI java.lang.String getDirectoryName()">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
@@ -5431,9 +5428,6 @@
     </annotation>
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="javax.swing.plaf.basic.BasicTransferable java.lang.Object getTransferData(java.awt.datatransfer.DataFlavor)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.swing.plaf.basic.BasicTreeUI boolean access$1000(javax.swing.plaf.basic.BasicTreeUI) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
@@ -5508,13 +5502,7 @@
   <item name="javax.swing.plaf.basic.BasicTreeUI java.awt.Dimension getMaximumSize(javax.swing.JComponent) 0">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="javax.swing.plaf.basic.BasicTreeUI java.awt.Dimension getMaximumSize(javax.swing.JComponent)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.swing.plaf.basic.BasicTreeUI java.awt.Dimension getMinimumSize(javax.swing.JComponent) 0">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="javax.swing.plaf.basic.BasicTreeUI java.awt.Dimension getMinimumSize(javax.swing.JComponent)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="javax.swing.plaf.basic.BasicTreeUI java.awt.Dimension getPreferredMinSize()">

--- a/results/jdk7-rt.jar/javax/swing/text/annotations.xml
+++ b/results/jdk7-rt.jar/javax/swing/text/annotations.xml
@@ -837,9 +837,6 @@
   <item name="javax.swing.text.FieldView java.awt.Shape modelToView(int, java.awt.Shape, javax.swing.text.Position.Bias) 2">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="javax.swing.text.FieldView java.awt.Shape modelToView(int, java.awt.Shape, javax.swing.text.Position.Bias)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.swing.text.FieldView void paint(java.awt.Graphics, java.awt.Shape) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
@@ -1850,9 +1847,6 @@
     </annotation>
   </item>
   <item name="javax.swing.text.PlainView java.awt.Shape modelToView(int, java.awt.Shape, javax.swing.text.Position.Bias) 2">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="javax.swing.text.PlainView java.awt.Shape modelToView(int, java.awt.Shape, javax.swing.text.Position.Bias)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="javax.swing.text.PlainView void damageLineRange(int, int, java.awt.Shape, java.awt.Component) 2">

--- a/results/jdk7-rt.jar/javax/swing/text/html/annotations.xml
+++ b/results/jdk7-rt.jar/javax/swing/text/html/annotations.xml
@@ -662,9 +662,6 @@
   <item name="javax.swing.text.html.CSS.BorderWidthValue java.lang.Object parseCssValue(java.lang.String)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="javax.swing.text.html.CSS.BorderWidthValue java.lang.Object parseHtmlValue(java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.swing.text.html.CSS.ColorValue java.lang.Object fromStyleConstants(javax.swing.text.StyleConstants, java.lang.Object) 0">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
@@ -742,9 +739,6 @@
   <item name="javax.swing.text.html.CSS.FontSize java.lang.Object fromStyleConstants(javax.swing.text.StyleConstants, java.lang.Object) 1">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="javax.swing.text.html.CSS.FontSize java.lang.Object fromStyleConstants(javax.swing.text.StyleConstants, java.lang.Object)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="javax.swing.text.html.CSS.FontSize java.lang.Object parseCssValue(java.lang.String)">
     <annotation name="org.jetbrains.annotations.Contract">
       <val val="&quot;null-&gt;null&quot;"/>
@@ -771,9 +765,6 @@
   </item>
   <item name="javax.swing.text.html.CSS.FontWeight java.lang.Object fromStyleConstants(javax.swing.text.StyleConstants, java.lang.Object) 1">
     <annotation name="org.jetbrains.annotations.NotNull"/>
-  </item>
-  <item name="javax.swing.text.html.CSS.FontWeight java.lang.Object fromStyleConstants(javax.swing.text.StyleConstants, java.lang.Object)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="javax.swing.text.html.CSS.FontWeight java.lang.Object parseCssValue(java.lang.String) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
@@ -813,9 +804,6 @@
   </item>
   <item name="javax.swing.text.html.CSS.LengthValue java.lang.Object parseHtmlValue(java.lang.String) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
-  </item>
-  <item name="javax.swing.text.html.CSS.LengthValue java.lang.Object parseHtmlValue(java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="javax.swing.text.html.CSS.LengthValue java.lang.Object toStyleConstants(javax.swing.text.StyleConstants, javax.swing.text.View) 0">
     <annotation name="org.jetbrains.annotations.Nullable"/>
@@ -2497,9 +2485,6 @@
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
   <item name="javax.swing.text.html.StyleSheet.ViewAttributeSet java.lang.Object doGetAttribute(java.lang.Object)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
-  <item name="javax.swing.text.html.StyleSheet.ViewAttributeSet java.lang.Object getAttribute(java.lang.Object)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
   <item name="javax.swing.text.html.StyleSheet.ViewAttributeSet javax.swing.text.AttributeSet getResolveParent()">

--- a/results/jdk7-rt.jar/sun/awt/X11/annotations.xml
+++ b/results/jdk7-rt.jar/sun/awt/X11/annotations.xml
@@ -3055,9 +3055,6 @@
   <item name="sun.awt.X11.XMenuItemPeer sun.awt.X11.XMenuItemPeer.TextMetrics calcTextMetrics()">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>
-  <item name="sun.awt.X11.XMenuItemPeer sun.awt.X11.XMenuItemPeer.TextMetrics getTextMetrics()">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="sun.awt.X11.XMenuItemPeer void setFont(java.awt.Font) 0">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>

--- a/results/jdk7-rt.jar/sun/awt/annotations.xml
+++ b/results/jdk7-rt.jar/sun/awt/annotations.xml
@@ -1683,9 +1683,6 @@
   <item name="sun.awt.UNIXToolkit java.lang.Object lazilyLoadDesktopProperty(java.lang.String) 0">
     <annotation name="org.jetbrains.annotations.NotNull"/>
   </item>
-  <item name="sun.awt.UNIXToolkit java.lang.Object lazilyLoadDesktopProperty(java.lang.String)">
-    <annotation name="org.jetbrains.annotations.Nullable"/>
-  </item>
   <item name="sun.awt.UNIXToolkit java.lang.Object lazilyLoadGTKIcon(java.lang.String)">
     <annotation name="org.jetbrains.annotations.Nullable"/>
   </item>

--- a/src/main/scala/asm/nullableResult.scala
+++ b/src/main/scala/asm/nullableResult.scala
@@ -189,7 +189,7 @@ case class NullableResultInterpreter(insns: InsnList, origins: Array[Boolean]) e
     opCode match {
       case INVOKESTATIC | INVOKESPECIAL | INVOKEVIRTUAL if origins(insns.indexOf(insn)) =>
         val stable =
-          (opCode == INVOKESTATIC) || (opCode == INVOKESPECIAL) || values.get(0).isInstanceOf[ThisValue]
+          (opCode == INVOKESTATIC) || (opCode == INVOKESPECIAL)
         val mNode = insn.asInstanceOf[MethodInsnNode]
         val method = Method(mNode.owner, mNode.name, mNode.desc)
         return Calls(Set(Key(method, Out, stable)))


### PR DESCRIPTION
Handles the problem of false positive `@Nullable` methods in cases when the result is a delegated call to a method that can be overridden. More conservative analysis doesn't handle call to `this.someVirtualMethod(...)` as a stable call. In this mode `ThreadLocal.get()` is not marked as `@Nullable` anymore.
